### PR TITLE
minor: improve client-side error parsing

### DIFF
--- a/ledger_analytics/requester.py
+++ b/ledger_analytics/requester.py
@@ -36,11 +36,36 @@ class Requester(object):
         try:
             message = response.json()
         except requests.exceptions.JSONDecodeError:
-            message = response
+            # handle HTML error pages (i.e. Django debug pages)
+            if "text/html" in response.headers.get("content-type", ""):
+                import re
+
+                # find exception type and value
+                exception_type = re.search(
+                    r'<th scope="row">Exception Type:</th>\s*<td>(.*?)</td>',
+                    response.text,
+                )
+                exception_value = re.search(
+                    r'<th scope="row">Exception Value:</th>\s*<td><pre>(.*?)</pre></td>',
+                    response.text,
+                )
+
+                if exception_type and exception_value:
+                    message = f"{exception_type.group(1)}: {exception_value.group(1)}"
+                else:
+                    # fallback if exception details not found
+                    title_match = re.search(r"<title>(.*?)</title>", response.text)
+                    message = (
+                        title_match.group(1).strip() if title_match else "Unknown error"
+                    )
+            else:
+                # for non-HTML responses, try to get plain text
+                message = response.text.strip() if response.text else str(response)
+
         match status:
             case 404:
                 raise requests.HTTPError(
-                    f"404: Cannot find the given endpoint, {message}."
+                    f"404: Cannot find the given endpoint, {message}"
                 )
             case 403:
                 raise requests.HTTPError(


### PR DESCRIPTION
Before if you set a triangle name or model name incorrectly, you would jsut get a `<Response[500]>` object in the error message that was difficult to understand (without opening it up into an HTML reader). Now if we get HTML back, we parse such that we get more readable errors in the console: 

```
dev_model = client.development_model.create(
    triangle="clipped_meyers", 
    model_name="chain_ladder_nate", 
    model_type="BADMODELTYPE"
)

> raise requests.HTTPError(f"500: Internal server error, {message}")
requests.exceptions.HTTPError: 500: Internal server error, DoesNotExist: DevelopmentModelType matching query does not exist.
```

```
dev_model = client.development_model.create(
    triangle="BADTRINAME", 
    model_name="chain_ladder_nate", 
    model_type="ChainLadder"
)

> raise requests.HTTPError(f"500: Internal server error, {message}")
requests.exceptions.HTTPError: 500: Internal server error, DoesNotExist: Triangle matching query does not exist.
```
