### PR TITLE
patch: website link

### DIFF
--- a/docs/source/ecosystem.rst
+++ b/docs/source/ecosystem.rst
@@ -1,7 +1,7 @@
 Our Software
 =====================
 
-`Ledger Investing <ledgerinvesting.com>`_ is open-sourcing and releasing
+`Ledger Investing <https://ledgerinvesting.com>`_ is open-sourcing and releasing
 our state-of-the-art analytics infrastructure to insurance data scientists
 and actuaries.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 LedgerAnalytics Python
 ===========================
 
-LedgerAnalytics Python is the Python interface to `Ledger Investing <ledgerinvesting.com>`_'s
+LedgerAnalytics Python is the Python interface to `Ledger Investing <https://ledgerinvesting.com>`_'s
 analytics infrastructure. Our analytics API endpoints allow easy access to Ledger's suite of
 reliable, scalable and state-of-the-art insurance data science models and data structures.
 LedgerAnalytics Python efficiently makes HTTP requests to these endpoints, integrating with


### PR DESCRIPTION
The web link was previously just appending `ledgerinvesting.com` to the read the docs URL, this fix makes it such that the hyperref points to the right place