### PR TITLE
fix: triangle intergration test

### DIFF
--- a/ledger_analytics/interface.py
+++ b/ledger_analytics/interface.py
@@ -128,7 +128,7 @@ class TriangleInterface(metaclass=TriangleRegistry):
         triangles = [
             result
             for result in self.list(limit=n_triangles).get("results")
-            if result.get("name") == name or result.get("id") == id
+            if result["name"] == name or result["id"] == id
         ]
         if not len(triangles):
             name_or_id = f"name '{name}'" if id is None else f"ID '{id}'"

--- a/ledger_analytics/triangle.py
+++ b/ledger_analytics/triangle.py
@@ -65,13 +65,14 @@ class Triangle(TriangleInterface):
                         )
                         url = get_response.json().get("url")
                         url_response = requests.get(url)
+                        url_response.raise_for_status()
                         with NamedTemporaryFile(suffix=".trib") as f:
                             f.write(url_response.content)
                             triangle_data = BermudaTriangle.from_binary(
                                 f.name
                             ).to_dict()
                     else:
-                        triangle_data = (get_response.json().get("triangle_data"),)
+                        triangle_data = get_response.json().get("triangle_data")
                 except ChunkedEncodingError:
                     stream = True
                     continue

--- a/test/integration/test_triangle.py
+++ b/test/integration/test_triangle.py
@@ -35,12 +35,14 @@ def test_triangle_create_delete(client):
 def test_triangle_captured_output(client):
     os.environ["DISABLE_RICH_CONSOLE"] = "true"
     name = "__test_tri_meyers"
-    test_tri = client.triangle.get_or_create(name=name, data=meyers_tri.to_dict())
+    client.triangle.create(name=name, data=meyers_tri.to_dict())
+    test_tri = client.triangle.get(name=name)
     assert test_tri.captured_stdout
     test_tri.delete()
 
     os.environ["DISABLE_RICH_CONSOLE"] = "false"
     name = "__test_tri_meyers"
-    test_tri = client.triangle.get_or_create(name=name, data=meyers_tri.to_dict())
+    client.triangle.create(name=name, data=meyers_tri.to_dict())
+    test_tri = client.triangle.get(name=name)
     assert not test_tri.captured_stdout
     test_tri.delete()


### PR DESCRIPTION
Small QOL fix to triangle integration tests for the stdout capturing. We need to create the triangle objects then `get` to capture/not capture the stdout properly. If we just call `get_or_create`, the create step does not capture the stdout that we want to test against.